### PR TITLE
[WUKONG-41] bypass the volume configration to retain data in container

### DIFF
--- a/docker/mysql/5.7rc/Dockerfile
+++ b/docker/mysql/5.7rc/Dockerfile
@@ -4,3 +4,6 @@ MAINTAINER Hua(Nelson) Qiao
 
 COPY custom.cnf /etc/mysql/conf.d/ 
 
+# bypass mysql volume configuration to retain data inside container
+RUN mkdir /var/lib/mysql-local-datadir
+CMD ["--datadir", "/var/lib/mysql-local-datadir"]


### PR DESCRIPTION
Use the option 1 in https://medium.com/@pybrarian/mysql-databases-that-dont-retain-data-293bc2ed7f02 to approach